### PR TITLE
Support hi-dpi tiles

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='osmviz',
-    version='1.0.1',
+    version='1.1',
     description='OSMViz is a small set of Python tools for retrieving '
                 'and using Mapnik tiles from a Slippy Map server '
                 '(you may know these as OpenStreetMap images).',

--- a/src/osmviz/manager.py
+++ b/src/osmviz/manager.py
@@ -268,7 +268,7 @@ class OSMManager(object):
 
         # Make a hash of the server URL to use in cached tile filenames.
         md5 = hashlib.md5()
-        md5.update(self.url.replace('{s}', str(self.scale)).encode("utf-8"))
+        md5.update(self.url.format(s=str(self.scale)).encode("utf-8"))
         self.cache_prefix = 'osmviz-%s-' % md5.hexdigest()[:5]
 
         if mgr:  # Assume it's a valid manager
@@ -295,11 +295,8 @@ class OSMManager(object):
         Given x, y coord of the tile to download, and the zoom level,
         returns the URL from which to download the image.
         """
-        return self.url \
-            .replace("{z}", str(zoom)) \
-            .replace("{x}", str(tile_coord[0])) \
-            .replace("{y}", str(tile_coord[1])) \
-            .replace("{s}", str(self.scale))
+        return self.url.format(x=str(tile_coord[0]), y=str(tile_coord[1]),
+                               z=str(zoom), s=str(self.scale))
 
     def getLocalTileFilename(self, tile_coord, zoom):
         """

--- a/src/osmviz/manager.py
+++ b/src/osmviz/manager.py
@@ -268,7 +268,7 @@ class OSMManager(object):
 
         # Make a hash of the server URL to use in cached tile filenames.
         md5 = hashlib.md5()
-        md5.update(self.url.format(s=str(self.scale)).encode("utf-8"))
+        md5.update(self.url.replace("{s}", str(self.scale)).encode("utf-8"))
         self.cache_prefix = 'osmviz-%s-' % md5.hexdigest()[:5]
 
         if mgr:  # Assume it's a valid manager

--- a/src/osmviz/manager.py
+++ b/src/osmviz/manager.py
@@ -193,16 +193,17 @@ class OSMManager(object):
         url - Full URL template from which to retrieve OSM tiles. This should
                     be fully qualified, including the protocol, and should
                     contain placeholders for zoom ('{z}'), coordinate x and y
-                    ('{x}' and '{y}'), and optionally scale ('{s}') for hi-dpi
-                    tile retrieval.
+                    ('{x}' and '{y}'), and optionally scale ('{s}') for high-
+                    resolution tile retrieval.
                     Note: when specified, the server parameter is ignored.
-                    Default: server appended with "/{z}/{x}/{y}.png"
+                    Default: server with "/{z}/{x}/{y}.png" appended
 
-        scale - Scale to use for hi-dpi tiles. Note that both url and scale
-                    must be set correctly for correct hi-dpi support. Normal
-                    tiles are 256, hi-dpi tiles are scale times 256 (e.g.,
-                    512 when scale is 2).
-                    Default 1 (regular dpi)
+        scale - Scale to use for high-resolution tiles. Note that both URL and
+                    scale must be set correctly for correct high-resolution
+                    support. Standard tile size is 256 pixels, high-resolution
+                    tiles are scale times 256 pixels (e.g., 512 pixels when
+                    scale is 2).
+                    Default 1 (standard resolution)
 
         image_manager - ImageManager instance which will be used to do all
                             image manipulation. You must provide this.
@@ -239,12 +240,12 @@ class OSMManager(object):
                 raise Exception("Unable to find/create/use maptile cache "
                                 "directory.")
 
-        # Get url template, which supports the following fields:
+        # Get URL template, which supports the following fields:
         #  * {z}: tile zoom level
         #  * {x}, {y}: coordinate x and y
-        #  * {s}: hidpi scale factor.
-        # Note: hi-dpi is not currently supported by the default OSM tile
-        # servers, but this can look like this, for example:
+        #  * {s}: high-resolution scale factor.
+        # Note: high-resolution is not currently supported by the default OSM
+        # tile servers, but this can look like this, for example:
         #  * http://server/layer@{s}x/{z}/{x}/{y}.png
         #  * http://server/layer/{z}/{x}/{y}@{s}x.png (e.g. Mapbox)
         #  * http://server/layer/{z}/{x}/{y}.png?scale={s} (e.g. Google Maps)
@@ -255,13 +256,14 @@ class OSMManager(object):
         else:
             self.url = "http://tile.openstreetmap.org/{z}/{x}/{y}.png"
 
-        # Default scale is 1x. Hi-dpi tiles can be 2x, 3x, 4x or even higher
+        # Default scale is 1. High-resolution tiles use 1.5, 2 (most common),
+        # 3, 4 or even more.
         if scale:
             self.scale = scale
         else:
             self.scale = 1
 
-        # Tile size is 256 multiplied by scale
+        # Tile size is 256 pixels multiplied by scale
         self.tile_size = 256 * self.scale
 
         # Make a hash of the server URL to use in cached tile filenames.

--- a/src/osmviz/manager.py
+++ b/src/osmviz/manager.py
@@ -295,8 +295,8 @@ class OSMManager(object):
         Given x, y coord of the tile to download, and the zoom level,
         returns the URL from which to download the image.
         """
-        return self.url.format(x=str(tile_coord[0]), y=str(tile_coord[1]),
-                               z=str(zoom), s=str(self.scale))
+        return self.url.format(x=tile_coord[0], y=tile_coord[1], z=zoom,
+                               s=self.scale)
 
     def getLocalTileFilename(self, tile_coord, zoom):
         """


### PR DESCRIPTION
_note: built on top of #1 (2to3) PR_

This PR adds support for hi-dpi tiles, by adding two options "scale" and "url" (see code). The developer (or "user") of the library has to take care that matching url and scale parameters are supplied, as it is impossible to test their combined validity:
* A scale value of 1 (the default) should probably be omitted from the url but maybe not, this depends on tile server implementation.
* Likewise, a scale factor different from 1 can also be used with a url template with the scale factor already built-in or even hidden as "part of the contract".

This PR should be backward compatible with the previous version, so I've only upped the minor version component.