### PR TITLE
Change setting the user-agent to make it work in Python 3.6

### DIFF
--- a/src/osmviz/manager.py
+++ b/src/osmviz/manager.py
@@ -390,5 +390,5 @@ class OSMManager(object):
 # import httplib
 # httplib.HTTPConnection.debuglevel = 1
 opener = urllib.request.build_opener()
-opener.addheaders = [('User-agent', 'OSMViz/1.1.0 +https://hugovk.github.io/osmviz')]
+opener.addheaders = [("User-agent", "OSMViz/1.1.0 +https://hugovk.github.io/osmviz")]
 urllib.request.install_opener(opener)

--- a/src/osmviz/manager.py
+++ b/src/osmviz/manager.py
@@ -39,7 +39,7 @@ import math
 import os
 import os.path as path
 import urllib.request
-from urllib.request import FancyURLopener, urlretrieve
+from urllib.request import urlretrieve
 
 try:
     from tqdm import tqdm

--- a/src/osmviz/manager.py
+++ b/src/osmviz/manager.py
@@ -387,16 +387,8 @@ class OSMManager(object):
         )
 
 
-class _useragenthack(FancyURLopener):
-    def __init__(self, *args):
-        FancyURLopener.__init__(self, *args)
-        for i, (header, val) in enumerate(self.addheaders):
-            if header == "User-Agent":
-                del self.addheaders[i]
-                break
-        self.addheader("User-Agent", "OSMViz/1.1.0 +https://hugovk.github.io/osmviz")
-
-
 # import httplib
 # httplib.HTTPConnection.debuglevel = 1
-urllib.request._urlopener = _useragenthack()
+opener = urllib.request.build_opener()
+opener.addheaders = [('User-agent', 'OSMViz/1.1.0 +https://hugovk.github.io/osmviz')]
+urllib.request.install_opener(opener)


### PR DESCRIPTION
osmviz stopped working for me at some point with an HTTP 403 error, it worked again if I replaced the existing hack for useragent with a different approach. 

I did not test it extensively with different versions of Python3, but it seems to work better than the previous approach on current Ubuntu Buster.