### PR TITLE
setuptools_scm includes EVERYTHING in Git unless explicitly excluded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,10 @@ matrix:
       dist: xenial
     - python: '3.6'
     - python: '3.5'
+    - python: '3.8-dev'
 
 install:
+ - pip install -U check-manifest
  - pip install -U coverage
  - pip install -U flake8
  - pip install -U pillow
@@ -30,6 +32,7 @@ script:
  # Static analysis
  - flake8 setup.py src test examples
  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then black --check --diff setup.py src test examples; fi
+ - check-manifest
 
 after_success:
  - coverage report

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,10 @@
 include LICENSE
 include README.md
+prune examples
+prune html
+prune test
+exclude .flake8
+exclude .gitignore
+exclude .travis.yml
+exclude index.html
+exclude RELEASING.md


### PR DESCRIPTION
Adding `setuptools_scm` (https://github.com/hugovk/osmviz/pull/29) made versioning and releasing a huge amount simpler, but inadvertently included lots more files:

```console
$ l /tmp/Downloads/osmviz-3.1.*
-rw-r--r--@ 1 hugo  wheel    12K 15 Jul 22:59 /tmp/Downloads/osmviz-3.1.0.tar.gz
-rw-r--r--@ 1 hugo  wheel   636K 15 Jul 22:59 /tmp/Downloads/osmviz-3.1.1.tar.gz
```

![image](https://user-images.githubusercontent.com/1324225/61245947-5e24b200-a756-11e9-81b5-4b0af2eec58c.png)

See https://github.com/pypa/setuptools_scm/pull/343.

Explicitly exclude/prune the other files/dirs to get it as it was before.
