### PR TITLE
Codecov now supports tokenless upload for GHA

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+# .coveragerc to control coverage.py
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma:
+    pragma: no cover
+
+    # Don't complain if non-runnable code isn't run:
+    if __name__ == .__main__.:
+    def main

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
         python-version: [3.8]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: pip cache
         uses: actions/cache@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,15 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.6", "3.7", "3.8"]
-        os: [ubuntu-18.04, ubuntu-16.04, macOS-latest]
+        os: [ubuntu-18.04, ubuntu-16.04, macos-latest]
+        include:
+          # Include new variables for Codecov
+          - os: ubuntu-18.04
+            codecov-flag: GHA_Ubuntu_18
+          - os: ubuntu-16.04
+            codecov-flag: GHA_Ubuntu_16
+          - os: macos-latest
+            codecov-flag: GHA_macOS
 
     steps:
       - uses: actions/checkout@v1
@@ -51,9 +59,10 @@ jobs:
         run: |
           tox -e py
 
-      - name: Upload coverage to Codecov
+      - name: Upload coverage
+        if: success()
         run: |
-          python -m pip install --upgrade codecov
-          codecov --name "GH: ${{ matrix.os }} Python ${{ matrix.python-version }}"
+          curl -s https://codecov.io/bash -o codecov.sh
+          bash codecov.sh -F ${{ matrix.codecov-flag }}
         env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          CODECOV_NAME: ${{ matrix.os }} Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
             codecov-flag: GHA_macOS
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Ubuntu cache
         uses: actions/cache@v1

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ commands =
     # Unit tests
     {envpython} -m pytest --cov osmviz --cov-append test/unit/test_manager.py {posargs}
     {envpython} -m pytest --cov osmviz --cov-append test/functional/test_manager.py {posargs}
+    coverage xml
 
 # Test at least one version with tqdm
 [testenv:py37]

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,8 @@ commands =
     coverage erase
 
     # Unit tests
-    {envpython} -m pytest --cov osmviz --cov-append test/unit/test_manager.py {posargs}
-    {envpython} -m pytest --cov osmviz --cov-append test/functional/test_manager.py {posargs}
+    {envpython} -m pytest --cov osmviz --cov test --cov-append test/unit/test_manager.py {posargs}
+    {envpython} -m pytest --cov osmviz --cov test --cov-append test/functional/test_manager.py {posargs}
     coverage xml
 
 # Test at least one version with tqdm


### PR DESCRIPTION
Codecov now supports tokenless uploads for GitHub Actions

* https://community.codecov.io/t/whitelist-github-action-servers-to-upload-without-a-token/491/17

Also use v2 of `actions/checkout`

* https://github.com/actions/checkout/releases/tag/v2.0.0

And cover tests

* https://nedbatchelder.com/blog/201908/dont_omit_tests_from_coverage.html