### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,18 +19,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: deploy-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            deploy-
-
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: "3.10"
+          cache: pip
+          cache-dependency-path: "setup.py"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macos-latest]
         include:
           # Include new variables for Codecov
@@ -25,21 +25,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key:
-            ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')
-            }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.python-version }}-
+          cache: pip
+          cache-dependency-path: "setup.py"
 
       - name: Install dependencies
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,13 @@ repos:
     rev: v2.29.0
     hooks:
       - id: pyupgrade
-        args: ["--py36-plus"]
+        args: [--py37-plus]
 
   - repo: https://github.com/psf/black
     rev: 21.9b0
     hooks:
       - id: black
-        args: ["--target-version", "py36"]
+        args: [--target-version=py37]
         exclude: ^html/
 
   - repo: https://github.com/PyCQA/isort

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ and using Mapnik tiles from a Slippy Map server
 
 ## Requirements
 
-* Python 3.6+
+* Python 3.7+
 * Pillow and/or Pygame
 
 ## Installation

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ long_description_content_type = text/markdown
 url = https://github.com/hugovk/osmviz
 author = Colin Bick and Contributors
 author_email = colin.bick@gmail.com
+maintainer = Hugo van Kemenade
 license = MIT
 license_file = LICENSE
 classifiers =
@@ -13,7 +14,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -31,7 +31,7 @@ requires =
 
 [options]
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 include_package_data = True
 package_dir = =src
 setup_requires =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint
-    py{py3, 310, 39, 38, 37, 36}
+    py{py3, 310, 39, 38, 37}
 
 [testenv]
 passenv =
@@ -33,7 +33,6 @@ deps =
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39


### PR DESCRIPTION
New version of https://github.com/hugovk/osmviz/pull/46 now https://github.com/hugovk/osmviz/pull/49 released.

| cycle | latest |  release   |    eol     |
|:------|:-------|:----------:|:----------:|
| 3.10  | 3.10.0 | 2021-10-04 | 2026-10-04 |
| 3.9   | 3.9.9  | 2020-10-05 | 2025-10-05 |
| 3.8   | 3.8.12 | 2019-10-14 | 2024-10-14 |
| 3.7   | 3.7.12 | 2018-06-27 | 2023-06-27 |
| 3.6   | 3.6.15 | 2016-12-23 | 2021-12-23 |

