### PR TITLE
Fix DeprecationWarning: `Image.ANTIALIAS` -> `Image.Resampling.LANCZOS`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -12,7 +12,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: micnncim/action-label-syncer@v1
         with:
           prune: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
       - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
           - { codecov-flag: GHA_macOS, os: macos-latest }
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.0
+    rev: v2.31.1
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
 
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
       - id: black
         args: [--target-version=py37]
@@ -39,7 +39,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.20.0
+    rev: v1.20.1
     hooks:
       - id: setup-cfg-fmt
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ where = src
 [options.extras_require]
 tests =
     coverage
-    pillow
+    pillow>=9.1.0
     pytest
     pytest-cov
 

--- a/src/osmviz/manager.py
+++ b/src/osmviz/manager.py
@@ -288,7 +288,7 @@ class OSMManager:
         (https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Python)
         """
         lat_rad = lat_deg * math.pi / 180.0
-        n = 2.0 ** zoom
+        n = 2.0**zoom
         xtile = int((lon_deg + 180.0) / 360.0 * n)
         ytile = int(
             (1.0 - math.log(math.tan(lat_rad) + (1 / math.cos(lat_rad))) / math.pi)
@@ -337,7 +337,7 @@ class OSMManager:
         left corner of the tile.
         """
         x_tile, y_tile = tile_coord
-        n = 2.0 ** zoom
+        n = 2.0**zoom
         lon_deg = x_tile / n * 360.0 - 180.0
         lat_rad = math.atan(math.sinh(math.pi * (1 - 2 * y_tile / n)))
         lat_deg = lat_rad * 180.0 / math.pi

--- a/test/functional/test_manager.py
+++ b/test/functional/test_manager.py
@@ -8,7 +8,7 @@ def test_pil():
     osm = OSMManager(image_manager=image_manager)
     image, bounds = osm.create_osm_image((30, 31, -117, -116), 9)
     wh_ratio = float(image.size[0]) / image.size[1]
-    image2 = image.resize((int(800 * wh_ratio), 800), Image.ANTIALIAS)
+    image2 = image.resize((int(800 * wh_ratio), 800), Image.Resampling.LANCZOS)
     del image
     image2.show()
 

--- a/tox.ini
+++ b/tox.ini
@@ -37,4 +37,4 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
-    pypy3: pypy3
+    pypy-3: pypy3


### PR DESCRIPTION
Fixes:

> DeprecationWarning: ANTIALIAS is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.LANCZOS instead.

https://pillow.readthedocs.io/en/stable/deprecations.html#constants

Also:
* Update Black to fix Click
* Fix PendingDeprecationWarning: Support of old-style PyPy config keys will be removed in tox-gh-actions v3
* Bump actions to v3