### PR TITLE
Fix examples: change `osmzoom` to `osm_zoom`

### DIFF
--- a/examples/custom_animations.py
+++ b/examples/custom_animations.py
@@ -121,4 +121,4 @@ train = TiedTrain(denver, 5.0, 5.0, 60, (0, 600), "Denver Bound")
 lasso = LassoViz(train.get_loc_at_time, lambda t: denver)
 
 sim = Simulation([train], [lasso], 0)
-sim.run(refresh_rate=0.01, speed=1, osmzoom=7)
+sim.run(refresh_rate=0.01, speed=1, osm_zoom=7)

--- a/examples/multiple_trackvizs.py
+++ b/examples/multiple_trackvizs.py
@@ -57,4 +57,4 @@ for i in range(num_trains):
 
 
 sim = Simulation(track_vizs, [], 0)
-sim.run(speed=1, refresh_rate=0.1, osmzoom=zoom)
+sim.run(speed=1, refresh_rate=0.1, osm_zoom=zoom)


### PR DESCRIPTION
Just a small change in the argument name defined in sim.run (the source specified it as `osm_zoom` but in the example files the argument used is `osmzoom`)