### PR TITLE
Remove default 'cache-dependency-path: pyproject.toml'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
           cache: pip
-          cache-dependency-path: pyproject.toml
+
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos