### PR TITLE
Add mypy

### DIFF
--- a/requirements-mypy.txt
+++ b/requirements-mypy.txt
@@ -1,0 +1,3 @@
+mypy==1.17.1
+pygame
+types-tqdm

--- a/src/osmviz/manager.py
+++ b/src/osmviz/manager.py
@@ -45,7 +45,7 @@ from urllib.request import urlretrieve
 try:
     from tqdm import tqdm
 except ImportError:
-    tqdm = None
+    tqdm = None  # type: ignore[assignment,misc]
 
 
 class ImageManager:
@@ -375,7 +375,7 @@ class OSMManager:
         self.manager.prepare_image(pix_width, pix_height)
         total = (1 + max_x - min_x) * (1 + max_y - min_y)
 
-        if tqdm:
+        if tqdm:  # type: ignore[truthy-function]
             pbar = tqdm(desc="Fetching tiles", total=total, unit="tile")
         else:
             print(f"Fetching {total} tiles...")
@@ -386,9 +386,9 @@ class OSMManager:
                 x_off = self.tile_size * (x - min_x)
                 y_off = self.tile_size * (y - min_y)
                 self.manager.paste_image_file(f_name, (x_off, y_off))
-                if tqdm:
+                if tqdm:  # type: ignore[truthy-function]
                     pbar.update()
-        if tqdm:
+        if tqdm:  # type: ignore[truthy-function]
             pbar.close()
         else:
             print("... done.")

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ requires =
     tox>=4.2
 env_list =
     lint
+    mypy
     py{py3, 314, 313, 312, 311, 310, 39}
 
 [testenv]
@@ -33,12 +34,12 @@ pass_env =
 commands =
     pre-commit run --all-files --show-diff-on-failure
 
+[testenv:mypy]
+deps =
+    -r requirements-mypy.txt
+commands =
+    mypy . {posargs}
+
 [testenv:py310]
 deps =
     tqdm
-
-[testenv:mypy]
-deps =
-    mypy==1.11.2
-commands =
-    mypy . {posargs}


### PR DESCRIPTION
Still some things to fix, so not in CI yet.

```console
❯ tox -e mypy
.pkg: _optional_hooks> python /Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/pyproject_api/_backend.py True hatchling.build
.pkg: get_requires_for_build_sdist> python /Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/pyproject_api/_backend.py True hatchling.build
.pkg: build_sdist> python /Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/pyproject_api/_backend.py True hatchling.build
mypy: install_package> python -I -m pip install --force-reinstall --no-deps /Users/hugo/github/osmviz/.tox/.tmp/package/11/osmviz-4.4.1.dev23.tar.gz
mypy: commands[0]> mypy .
src/osmviz/animation.py:367: error: Incompatible types in assignment (expression has type "float", variable has type "int")  [assignment]
src/osmviz/animation.py:369: error: Incompatible types in assignment (expression has type "float", variable has type "int")  [assignment]
examples/pil_example.py:16: error: Module has no attribute "ANTIALIAS"  [attr-defined]
examples/custom_animations.py:50: error: Argument 3 to "line" has incompatible type "None"; expected "tuple[float, float] | Sequence[float] | Vector2"  [arg-type]
examples/custom_animations.py:50: error: Argument 4 to "line" has incompatible type "None"; expected "tuple[float, float] | Sequence[float] | Vector2"  [arg-type]
Found 5 errors in 3 files (checked 11 source files)
mypy: exit 1 (0.82 seconds) /Users/hugo/github/osmviz> mypy . pid=41690
.pkg: _exit> python /Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/pyproject_api/_backend.py True hatchling.build
  mypy: FAIL code 1 (2.78=setup[1.96]+cmd[0.82] seconds)
  evaluation failed :( (2.89 seconds)
```
