### PR TITLE
Use more specific exceptions than `Exception`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.20
+    rev: v0.16.0
     hooks:
       - id: ruff-check
         args: [--exit-non-zero-on-fix]
@@ -38,12 +38,12 @@ repos:
       - id: actionlint
 
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.26.1
+    rev: v1.28.0
     hooks:
       - id: zizmor
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: v2.25.1
+    rev: v2.25.3
     hooks:
       - id: pyproject-fmt
 
@@ -53,7 +53,7 @@ repos:
       - id: validate-pyproject
 
   - repo: https://github.com/tox-dev/tox-ini-fmt
-    rev: 1.7.1
+    rev: 1.8.0
     hooks:
       - id: tox-ini-fmt
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ version.raw-options.local_scheme = "no-local-version"
 
 [tool.ruff]
 fix = true
-lint.select = [
+lint.extend-select = [
   "C4",     # flake8-comprehensions
   "E",      # pycodestyle errors
   "EM",     # flake8-errmsg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,22 +52,18 @@ version.raw-options.local_scheme = "no-local-version"
 [tool.ruff]
 fix = true
 lint.extend-select = [
-  "C4",     # flake8-comprehensions
-  "E",      # pycodestyle errors
-  "EM",     # flake8-errmsg
-  "F",      # pyflakes
-  "I",      # isort
-  "ICN",    # flake8-import-conventions
-  "ISC",    # flake8-implicit-str-concat
-  "LOG",    # flake8-logging
-  "PGH",    # pygrep-hooks
-  "PIE",    # flake8-pie
-  "PYI",    # flake8-pyi
-  "RUF022", # unsorted-dunder-all
-  "RUF100", # unused noqa (yesqa)
-  "UP",     # pyupgrade
-  "W",      # pycodestyle warnings
-  "YTT",    # flake8-2020
+  "C4",  # flake8-comprehensions
+  "E",   # pycodestyle errors
+  "EM",  # flake8-errmsg
+  "F",   # pyflakes
+  "I",   # isort
+  "ICN", # flake8-import-conventions
+  "ISC", # flake8-implicit-str-concat
+  "LOG", # flake8-logging
+  "PGH", # pygrep-hooks
+  "PYI", # flake8-pyi
+  "UP",  # pyupgrade
+  "W",   # pycodestyle warnings
 ]
 lint.ignore = [
   "E203",   # Whitespace before ':'

--- a/src/osmviz/animation.py
+++ b/src/osmviz/animation.py
@@ -131,7 +131,7 @@ class SimViz:
         viz object. Default behavior is to return None, meaning no
         label should ever be displayed.
         """
-        return None
+        return
 
     def mouse_intersect(self, mouse_x, mouse_y):
         """

--- a/src/osmviz/animation.py
+++ b/src/osmviz/animation.py
@@ -322,7 +322,7 @@ class Simulation:
         if isinstance(font, str):
             try:
                 fnt = pygame.font.Font(font, font_size)
-            except Exception:
+            except (OSError, RuntimeError):
                 fnt = None
         elif isinstance(font, pygame.font.Font):
             fnt = font

--- a/src/osmviz/manager.py
+++ b/src/osmviz/manager.py
@@ -90,7 +90,7 @@ class ImageManager:
         """
         if self.image:
             msg = "Image already prepared."
-            raise Exception(msg)
+            raise RuntimeError(msg)
         self.image = self.create_image(width, height)
 
     def destroy_image(self) -> None:
@@ -110,13 +110,13 @@ class ImageManager:
         """
         if not self.image:
             msg = "Image not prepared"
-            raise Exception(msg)
+            raise RuntimeError(msg)
 
         try:
             img = self.load_image_file(image_file)
-        except Exception as e:
+        except (OSError, ValueError, RuntimeError) as e:
             msg = f"Could not load image {image_file}\n{e}"
-            raise Exception(msg)
+            raise ValueError(msg)
 
         self.paste_image(img, xy)
         del img
@@ -140,7 +140,7 @@ class PygameImageManager(ImageManager):
             import pygame
         except ImportError:
             msg = "Pygame could not be imported!"
-            raise Exception(msg)
+            raise ImportError(msg)
         self.pygame = pygame
 
     def create_image(self, width, height):
@@ -170,7 +170,7 @@ class PILImageManager(ImageManager):
             import PIL.Image
         except ImportError:
             msg = "PIL could not be imported!"
-            raise Exception(msg)
+            raise ImportError(msg)
         self.PILImage = PIL.Image
 
     def create_image(self, width, height):
@@ -235,7 +235,7 @@ class OSMManager:
                     os.makedirs(cache, 0o766)
                     self.cache = cache
                     print("WARNING: Created cache dir", cache)
-                except Exception:
+                except OSError:
                     print("Could not make cache dir", cache)
             elif not os.access(cache, os.R_OK | os.W_OK):
                 print("Insufficient privileges on cache dir", cache)
@@ -250,7 +250,7 @@ class OSMManager:
             if not os.access(self.cache, os.R_OK | os.W_OK):
                 print(f" ERROR: Insufficient access to {self.cache}.")
                 msg = "Unable to find/create/use map tile cache directory."
-                raise Exception(msg)
+                raise RuntimeError(msg)
 
         # Get URL template, which supports the following fields:
         #  * {z}: tile zoom level
@@ -287,7 +287,7 @@ class OSMManager:
             self.manager = mgr
         else:
             msg = "OSMManager.__init__ requires argument image_manager"
-            raise Exception(msg)
+            raise TypeError(msg)
 
     def get_tile_coord(self, lon_deg, lat_deg, zoom):
         """
@@ -334,9 +334,9 @@ class OSMManager:
             url = self.get_tile_url(tile_coord, zoom)
             try:
                 urlretrieve(url, filename=filename)
-            except Exception as e:
+            except OSError as e:
                 msg = f"Unable to retrieve URL: {url}\n{e}"
-                raise Exception(msg)
+                raise OSError(msg)
         return filename
 
     def tile_nw_lat_lon(self, tile_coord, zoom):
@@ -364,7 +364,7 @@ class OSMManager:
         min_lat, max_lat, min_lon, max_lon = bounds
         if not self.manager:
             msg = "No ImageManager was specified, cannot create image."
-            raise Exception(msg)
+            raise ValueError(msg)
 
         topleft = min_x, min_y = self.get_tile_coord(min_lon, max_lat, zoom)
         max_x, max_y = self.get_tile_coord(max_lon, min_lat, zoom)

--- a/src/osmviz/manager.py
+++ b/src/osmviz/manager.py
@@ -38,8 +38,8 @@ from __future__ import annotations
 import hashlib
 import math
 import os
-import os.path as path
 import urllib.request
+from os import path
 from urllib.request import urlretrieve
 
 try:

--- a/test/functional/test_animation.py
+++ b/test/functional/test_animation.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import itertools
+
 from osmviz.animation import Simulation, TrackingViz
 
 Inf = float("inf")
@@ -31,7 +33,7 @@ def test_sim(route, zoom, image: str = "test/images/train.png") -> None:
         elif time > time_window[1]:
             return route[-1][:2]
 
-        for (lat1, lon1, time1), (lat2, lon2, time2) in zip(route[:-1], route[1:]):
+        for (lat1, lon1, time1), (lat2, lon2, time2) in itertools.pairwise(route):
             if time1 < time <= time2:
                 break
 

--- a/test/functional/test_manager.py
+++ b/test/functional/test_manager.py
@@ -8,7 +8,7 @@ from osmviz.manager import OSMManager, PILImageManager
 def test_pil() -> None:
     image_manager = PILImageManager("RGB")
     osm = OSMManager(image_manager=image_manager)
-    image, bounds = osm.create_osm_image((30, 31, -117, -116), 9)
+    image, _ = osm.create_osm_image((30, 31, -117, -116), 9)
     wh_ratio = float(image.size[0]) / image.size[1]
     image2 = image.resize((int(800 * wh_ratio), 800), Image.Resampling.LANCZOS)
     del image

--- a/test/functional/test_manager.py
+++ b/test/functional/test_manager.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import PIL.Image as Image
+from PIL import Image
 
 from osmviz.manager import OSMManager, PILImageManager
 

--- a/test/unit/test_pil_image_manager.py
+++ b/test/unit/test_pil_image_manager.py
@@ -35,7 +35,7 @@ def test_prepare_image__twice(image_manager) -> None:
     image_manager.prepare_image(width, height)
 
     # Assert
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         image_manager.prepare_image(width, height)
 
 
@@ -67,7 +67,7 @@ def test_paste_image_file__image_not_prepared(image_manager) -> None:
     xy = (0, 0)
 
     # Act / Assert
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         image_manager.paste_image_file(filename, xy)
 
 
@@ -80,7 +80,7 @@ def test_paste_image_file__could_not_load_image(image_manager) -> None:
     xy = (0, 0)
 
     # Act / Assert
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         image_manager.paste_image_file(filename, xy)
 
 


### PR DESCRIPTION
Upgrade to Ruff 16 and use `extend-select` to enable more default rules.

Fix new warnings, and deselect the new defaults from `extend-select`.

https://astral.sh/blog/ruff-v0.16.0